### PR TITLE
#58 - dependabot's prefix too long

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@ update_configs:
     directory: "/"
     target_branch: "develop"
     commit_message:
-      prefix: "#58 - (composer) "
+      prefix: "#58 - (php) "
 
   - package_manager: "javascript"
     update_schedule: "live"
     directory: "/"
     target_branch: "develop"
     commit_message:
-      prefix: "#58 - (npm) "
+      prefix: "#58 - (js) "

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Generate application key:
 php artisan key:generate
 ```
 
-Generate assets
+Generate assets:
 ```shell script
 npm run dev
 ```
@@ -70,7 +70,7 @@ docker-compose run -u "$(id -u):$(id -g)" node npm -v
 docker-compose run -u "$(id -u):$(id -g)" node npm install
 ```
 
-Go into PHP container:
+Go into Node container:
 ```shell script
 docker exec -it -u "$(id -u):$(id -g)" brewmap-node sh
 ```


### PR DESCRIPTION
One more try. It looks like we should validate `dependabot.yml` [here](https://dependabot.com/docs/config-file/validator/) before merging anything.