### PR TITLE
#98 - dependabot config for Docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,10 @@ update_configs:
     target_branch: "develop"
     commit_message:
       prefix: "#58 - (js) "
+
+  - package_manager: "docker"
+    update_schedule: "daily"
+    directory: "/"
+    target_branch: "develop"
+    commit_message:
+      prefix: "#58 - (docker) "


### PR DESCRIPTION
Should close #98. 

A `live` is not valid option for Docker for some reason [(docs)](https://dependabot.com/docs/config-file/#available-schedules), so I changed it to `daily`; it will fire only on weekdays.