### PR TITLE
#52 - flag as administrator

### DIFF
--- a/app/Eloquent/Observers/User.php
+++ b/app/Eloquent/Observers/User.php
@@ -14,10 +14,19 @@ class User
         if ($user->id === null) {
             $user->id = Str::uuid()->toString();
         }
+
+        if ($this->isFirstUser()) {
+            $user->isAdmin = true;
+        }
     }
 
     public function created(UserModel $user): void
     {
         $user->profile()->create();
+    }
+
+    protected function isFirstUser(): bool
+    {
+        return UserModel::query()->count() === 0;
     }
 }

--- a/app/Eloquent/User.php
+++ b/app/Eloquent/User.php
@@ -23,6 +23,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string $email
  * @property string|null $emailVerifiedAt
  * @property string|null $password
+ * @property boolean $isAdmin
  * @property string $rememberToken
  * @property Profile $profile
  * @property Collection|SocialProfile[] $socialProfiles
@@ -38,8 +39,8 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     use MustVerifyEmail;
     use Notifiable;
 
-    protected $casts = ["email_verified_at" => "datetime"];
-    protected $hidden = ["password", "remember_token"];
+    protected $casts = ["email_verified_at" => "datetime", "is_admin" => "boolean"];
+    protected $hidden = ["password", "remember_token", "is_admin"];
     protected $fillable = ["email", "password", "name"];
 
     public function profile(): HasOne

--- a/app/Nova/Resources/User.php
+++ b/app/Nova/Resources/User.php
@@ -6,6 +6,7 @@ namespace Brewmap\Nova\Resources;
 
 use Brewmap\Eloquent\User as EloquentUser;
 use Illuminate\Http\Request;
+use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\DateTime;
 use Laravel\Nova\Fields\Gravatar;
 use Laravel\Nova\Fields\ID;
@@ -35,6 +36,7 @@ class User extends Resource
                 ->rules(["required", "email", "max:254"])
                 ->creationRules(["unique:users,email"])
                 ->updateRules(["unique:users,email,{{resourceId}}"]),
+            Boolean::make('Administrator', 'is_admin'),
             DateTime::make("Email verified at")
                 ->sortable()
                 ->hideWhenCreating()

--- a/app/Nova/Resources/User.php
+++ b/app/Nova/Resources/User.php
@@ -36,7 +36,7 @@ class User extends Resource
                 ->rules(["required", "email", "max:254"])
                 ->creationRules(["unique:users,email"])
                 ->updateRules(["unique:users,email,{{resourceId}}"]),
-            Boolean::make('Administrator', 'is_admin'),
+            Boolean::make("Administrator", "is_admin"),
             DateTime::make("Email verified at")
                 ->sortable()
                 ->hideWhenCreating()

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -37,7 +37,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
         Gate::define(
             "viewNova",
             function (BrewmapUser $user): bool {
-                return true;
+                return $user->isAdmin;
             }
         );
     }

--- a/app/Providers/NovaServiceProvider.php
+++ b/app/Providers/NovaServiceProvider.php
@@ -34,12 +34,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
 
     protected function gate(): void
     {
-        Gate::define(
-            "viewNova",
-            function (BrewmapUser $user): bool {
-                return $user->isAdmin;
-            }
-        );
+        Gate::define("viewNova", fn (BrewmapUser $user): bool => $user->isAdmin);
     }
 
     protected function resources(): void

--- a/app/Testing/Context/Eloquent/Users.php
+++ b/app/Testing/Context/Eloquent/Users.php
@@ -9,6 +9,8 @@ use Behat\Gherkin\Node\TableNode;
 use Brewmap\Eloquent\Profile;
 use Brewmap\Eloquent\User;
 use Database\Factories\UserFactory;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Guard;
 use KrzysztofRewak\Larahat\Helpers\RefreshingDatabase;
 use PHPUnit\Framework\Assert;
 
@@ -57,5 +59,19 @@ class Users implements Context
             "%x%x%x%x%x%x%x%x-%x%x%x%x-%x%x%x%x-%x%x%x%x-%x%x%x%x%x%x%x%x%x%x%x%x",
             $this->user->id ?? ""
         );
+    }
+
+    /**
+     * @Given user is logged in as :email
+     */
+    public function userIsLoggedInAs(string $email): void
+    {
+        /** @var Guard $guard */
+        $guard = app(Guard::class);
+
+        /** @var Authenticatable $user */
+        $user = User::query()->where('email', $email)->first();
+
+        $guard->setUser($user);
     }
 }

--- a/app/Testing/Context/Eloquent/Users.php
+++ b/app/Testing/Context/Eloquent/Users.php
@@ -21,6 +21,20 @@ class Users implements Context
     protected User $user;
 
     /**
+     * @Given user is logged in as :email
+     */
+    public function userIsLoggedInAs(string $email): void
+    {
+        /** @var Guard $guard */
+        $guard = app(Guard::class);
+
+        /** @var Authenticatable $user */
+        $user = User::query()->where("email", $email)->first();
+
+        $guard->setUser($user);
+    }
+
+    /**
      * @When there is a user created
      */
     public function thereIsAUserCreated(): void
@@ -62,16 +76,14 @@ class Users implements Context
     }
 
     /**
-     * @Given user is logged in as :email
+     * @Then there should be is_admin assigned:
      */
-    public function userIsLoggedInAs(string $email): void
+    public function thereShouldBeIsAdminAssigned(TableNode $table): void
     {
-        /** @var Guard $guard */
-        $guard = app(Guard::class);
-
-        /** @var Authenticatable $user */
-        $user = User::query()->where("email", $email)->first();
-
-        $guard->setUser($user);
+        foreach ($table->getHash() as $data) {
+            /** @var User $user */
+            $user = User::query()->find($data["id"]);
+            Assert::assertEquals($data["is_admin"], (int)$user->isAdmin);
+        }
     }
 }

--- a/app/Testing/Context/Eloquent/Users.php
+++ b/app/Testing/Context/Eloquent/Users.php
@@ -70,7 +70,7 @@ class Users implements Context
         $guard = app(Guard::class);
 
         /** @var Authenticatable $user */
-        $user = User::query()->where('email', $email)->first();
+        $user = User::query()->where("email", $email)->first();
 
         $guard->setUser($user);
     }

--- a/behat.yml
+++ b/behat.yml
@@ -8,6 +8,7 @@ default:
       contexts:
         - Brewmap\Testing\Context\Application\Config
         - Brewmap\Testing\Context\InternalHttpRequesting
+        - Brewmap\Testing\Context\Eloquent\Users
       paths:
         - features/http
 

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -20,9 +20,7 @@ return [
         "web",
         Authorize::class,
     ],
-    "ignore_paths" => [
-        "nova-api*",
-    ],
+    "ignore_paths" => [],
     "ignore_commands" => [],
     "watchers" => [
         Watchers\CacheWatcher::class => env("TELESCOPE_CACHE_WATCHER", true),

--- a/config/telescope.php
+++ b/config/telescope.php
@@ -20,7 +20,9 @@ return [
         "web",
         Authorize::class,
     ],
-    "ignore_paths" => [],
+    "ignore_paths" => [
+        "nova-api*",
+    ],
     "ignore_commands" => [],
     "watchers" => [
         Watchers\CacheWatcher::class => env("TELESCOPE_CACHE_WATCHER", true),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -22,6 +22,7 @@ class UserFactory extends Factory
             "name" => $this->faker->name,
             "email" => $this->faker->unique()->safeEmail,
             "email_verified_at" => now(),
+            "is_admin" => false,
             "password" => $hash->make("password"),
             "remember_token" => Str::random(10),
         ];

--- a/database/migrations/2020_11_26_185827_change_action_event_ids_to_uuids.php
+++ b/database/migrations/2020_11_26_185827_change_action_event_ids_to_uuids.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangeActionEventIdsToUuids extends Migration
+{
+    public function up(): void
+    {
+        Schema::table("action_events", function (Blueprint $table): void {
+            $table->string("actionable_id", 36)->change();
+            $table->string("model_id", 36)->change();
+            $table->string("target_id", 36)->change();
+            $table->string("user_id", 36)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table("action_events", function (Blueprint $table): void {
+            $table->integer("actionable_id")->unsigned()->change();
+            $table->integer("model_id")->unsigned()->change();
+            $table->integer("target_id")->unsigned()->change();
+            $table->integer("user_id")->unsigned()->change();
+        });
+    }
+}

--- a/database/migrations/2020_11_26_191701_add_is_admin_column_to_users.php
+++ b/database/migrations/2020_11_26_191701_add_is_admin_column_to_users.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,15 +10,15 @@ class AddIsAdminColumnToUsers extends Migration
 {
     public function up(): void
     {
-        Schema::table('users', function (Blueprint $table): void {
-            $table->boolean('is_admin')->default(false);
+        Schema::table("users", function (Blueprint $table): void {
+            $table->boolean("is_admin")->default(false);
         });
     }
 
-    public function down()
+    public function down(): void
     {
-        Schema::table('users', function (Blueprint $table): void {
-            $table->dropColumn('is_admin');
+        Schema::table("users", function (Blueprint $table): void {
+            $table->dropColumn("is_admin");
         });
     }
 }

--- a/database/migrations/2020_11_26_191701_add_is_admin_column_to_users.php
+++ b/database/migrations/2020_11_26_191701_add_is_admin_column_to_users.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIsAdminColumnToUsers extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->boolean('is_admin')->default(false);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn('is_admin');
+        });
+    }
+}

--- a/features/eloquent/user.feature
+++ b/features/eloquent/user.feature
@@ -14,3 +14,13 @@ Feature: Test if users are working correctly
       | user_id                              |
       | 00000000-0000-0000-0000-000000000000 |
       | 00000000-0000-0000-0000-000000000001 |
+
+  Scenario: First created user should be an admin
+    When there is a user created:
+      | id                                   | email             |
+      | 00000000-0000-0000-0000-000000000000 | test1@example.com |
+      | 00000000-0000-0000-0000-000000000001 | test2@example.com |
+    Then there should be is_admin assigned:
+      | id                                   | is_admin |
+      | 00000000-0000-0000-0000-000000000000 | 1        |
+      | 00000000-0000-0000-0000-000000000001 | 0        |

--- a/features/http/dashboard.feature
+++ b/features/http/dashboard.feature
@@ -1,0 +1,25 @@
+@nova @dashboard @auth @views
+Feature: Test if dashboard works
+
+  Background:
+    Given there are users created:
+      | id                                   | email             | is_admin |
+      | 00000000-0000-0000-0000-000000000000 | admin@example.com | 1        |
+      | 00000000-0000-0000-0000-000000000001 | user@example.com  | 0        |
+
+  Scenario: User is requesting nova dashboard when he is not logged in
+    Given a user is requesting "/dashboard"
+    When a request is sent
+    Then a response status code should be "302"
+
+  Scenario: User is requesting nova dashboard when he is not an administrator
+    Given user is logged in as "user@example.com"
+    And a user is requesting "/dashboard"
+    When a request is sent
+    Then a response status code should be "403"
+
+  Scenario: User is requesting nova dashboard when he is an administrator
+    Given user is logged in as "admin@example.com"
+    And a user is requesting "/dashboard"
+    When a request is sent
+    Then a response status code should be "200"


### PR DESCRIPTION
My solution is the simplest possible. I just added a new field (is_admin) to the User model. I added an observer to ensure that the first created user is an admin.

NOTE:
If you want to test the functionality manually, you should change your env (APP_ENV) to something different, because nova skips checking gate('viewnova') on local environment.

It should close #52 